### PR TITLE
Changing the node version to fix error when running docker-composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #https://snyk.io/advisor/docker/node use the least vulnerable package
-FROM node:current-buster as builder
+FROM node:14-buster as builder
 RUN mkdir -p /build
 
 COPY ./package.json ./package-lock.json /build/
@@ -8,7 +8,7 @@ RUN npm ci
 
 COPY . /build
 
-FROM  node:18.6.0-slim 
+FROM  node:14-bullseye
 ENV user node
 USER $user
 


### PR DESCRIPTION
Changing the node version to fix error when running docker-composer

<img width="1433" alt="Captura de Tela 2024-05-22 às 13 39 09" src="https://github.com/SirAppSec/vuln-node.js-express.js-app/assets/103961031/28e48305-d8df-4640-8e1d-c663b29cf9b3">


After the change ->

<img width="796" alt="Captura de Tela 2024-05-22 às 13 39 55" src="https://github.com/SirAppSec/vuln-node.js-express.js-app/assets/103961031/5d6d1eeb-23e8-4a65-8c39-8ea9942fbbfb">
