### PR TITLE
fix(deps): bump sequelize from 6.21.3 to 6.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
     "pug": "^3.0.2",
-    "sequelize": "^6.21.3",
+    "sequelize": "^6.29.0",
     "sequelize-json-schema": "^2.1.1",
     "sqlite3": "^5.0.10",
     "swagger-jsdoc": "^6.2.1",


### PR DESCRIPTION
## Security Fix

Bumps `sequelize` from `6.21.3` to `6.29.0` to address 1 vulnerability.

| ID | Severity | Summary |
|----|----------|---------|
| GHSA-f598-mfpv-gmfx | CRITICAL | Sequelize - Default support for “raw attributes” when using parentheses |

---
_Generated by [NodeGuard](https://github.com/nodeguard/nodeguard)_